### PR TITLE
Add usage skills and fix broken examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ joss/
 !README.md
 !CHANGELOG.md
 !docs/changelog.md
+!skills/**/*.md

--- a/examples/run_omm_locally.py
+++ b/examples/run_omm_locally.py
@@ -6,8 +6,8 @@ path = Path('/path/to/simulation/inputs')
 sim_length = 10 # ns
 timestep = 4 # fs
 
-n_steps = sim_length / timestep * 1000000 # production steps
+n_steps = int(sim_length / timestep * 1_000_000) # production steps
 eq_steps = 500_000 # 1ns; 2 fs timestep
 
-simulator = Simulator(path, equil_steps=eq_steps, prod_steps=steps)
+simulator = Simulator(path, equil_steps=eq_steps, prod_steps=n_steps)
 simulator.run()

--- a/examples/run_omm_parsl.py
+++ b/examples/run_omm_parsl.py
@@ -1,19 +1,20 @@
 #!/usr/bin/env python
+from pathlib import Path
+
 import parsl
-from molecular_simulations.simulate import LocalSettings
+from molecular_simulations.utils.parsl_settings import LocalSettings
 
 # Housekeeping stuff
 run_dir = '/path/to/deploy/parsl' # likely same as root simulation dir
-sim_root_dir = '/path/to/deploy/parsl' # could be different
+sim_root_dir = Path('/path/to/deploy/parsl') # could be different
 paths = sim_root_dir.glob('replica_*') # get all sim replica dirs
 
-parsl_config = 'config.yaml'
 settings = LocalSettings.from_yaml('config.yaml')
 config = settings.config_factory(run_dir)
 
 sim_length = 10 # ns
 timestep = 4 # fs
-n_steps = sim_length / timestep * 1000000
+n_steps = int(sim_length / timestep * 1_000_000)
 
 @parsl.python_app
 def run_md(path: str, eq_steps=500_000, steps=250_000_000):
@@ -28,7 +29,7 @@ parsl.load(config)
 # collect futures
 futures = []
 for path in paths:
-    futures.append(run_md(path, steps=n_steps))
+    futures.append(run_md(str(path), steps=n_steps))
 
 # run workers in parallel
 outputs = [x.result() for x in futures]

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,18 @@
+# Skills
+
+Claude Code / agent skills for working with the `molecular-simulations` package.
+Each subdirectory holds a `SKILL.md` (name + description frontmatter) that the
+agent loads on demand when a task matches.
+
+| Skill | Use it for |
+|-------|------------|
+| [build-systems](build-systems/SKILL.md) | Building AMBER systems from PDB/CIF — explicit/implicit solvent, protein-ligand complexes, GAFF2 ligand parameterization |
+| [run-simulations](run-simulations/SKILL.md) | Running OpenMM MD — explicit NPT, implicit GB, minimization, MM-PBSA, restarts, platform selection |
+| [analyze-sasa](analyze-sasa/SKILL.md) | Solvent-accessible surface area — absolute SASA and RelativeSASA fractional exposure, per residue over a trajectory |
+| [analyze-ipsae](analyze-ipsae/SKILL.md) | ipSAE interface scoring of predicted complexes — ipSAE, ipTM, pDockQ, pDockQ2, LIS from pLDDT/PAE |
+| [analyze-interactions](analyze-interactions/SKILL.md) | Interaction-energy fingerprinting, linear interaction energy (static/dynamic), and KMeans clustering of per-frame features |
+| [parsl-hpc](parsl-hpc/SKILL.md) | Deploying builds/runs/analyses across HPC with Parsl — Local, Heterogeneous, Polaris, Aurora settings |
+
+Typical pipeline: **build-systems** → **run-simulations** → **analyze-sasa** /
+**analyze-ipsae** / **analyze-interactions**, with **parsl-hpc** wrapping any
+stage for parallel fan-out across nodes/GPUs.

--- a/skills/analyze-interactions/SKILL.md
+++ b/skills/analyze-interactions/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: analyze-interactions
+description: Analyze protein-protein/ligand interactions from MD trajectories with molecular-simulations — per-residue interaction-energy fingerprinting (electrostatic + Lennard-Jones), linear interaction energy (static structure or dynamic trajectory), and KMeans clustering of per-frame feature data. Use when characterizing binding interfaces, footprinting which residues drive an interaction, computing chain-chain interaction energies, or clustering conformations/fingerprints.
+---
+
+# Interaction & clustering analyses
+
+Three tools in `molecular_simulations.analysis` for characterizing how parts of a
+system interact and for grouping the resulting per-frame data:
+
+- **`Fingerprinter`** — per-residue interaction-energy fingerprints.
+- **`StaticInteractionEnergy` / `DynamicInteractionEnergy`** — linear interaction
+  energy between a chain and the rest of the system.
+- **`AutoKMeans`** — automatic KMeans++ clustering (with PCA) of `.npy` features.
+
+For surface accessibility see `analyze-sasa`; for predicted-complex interface
+scoring see `analyze-ipsae`.
+
+## Fingerprinter — per-residue interaction energy
+
+Computes per-residue Lennard-Jones and electrostatic interaction energy between a
+**target** selection and a **binder** selection across every trajectory frame.
+Reads nonbonded parameters (charge/sigma/epsilon) straight from an AMBER `.prmtop`.
+
+```python
+from molecular_simulations.analysis import Fingerprinter
+
+fp = Fingerprinter(
+    'complex.prmtop',
+    trajectory='prod.dcd',          # if None: looks for <stem>.inpcrd then .rst7
+    target_selection='segid A',     # MDAnalysis selection language
+    binder_selection=None,          # default: 'not <target_selection>'
+)
+fp.run()
+fp.save()                           # -> fingerprint.npz (next to topology)
+```
+
+Outputs (`np.savez` to `fingerprint.npz`):
+- `target` — array `(n_frames, n_target_residues, 2)`
+- `binder` — array `(n_frames, n_binder_residues, 2)`
+
+The last axis is `[LJ, electrostatic]` energy per residue per frame. Average over
+axis 0 to get a per-residue footprint of which residues drive the interaction.
+
+Notes:
+- Requires an AMBER `.prmtop` (an OpenMM `System` is built to read nonbonded
+  params). A PDB-only topology won't have force-field parameters.
+- `out_path` / `out_name` override the default output location/filename.
+- Add chain IDs/segids first with `molecular_simulations.build.add_chains` if your
+  structure lacks them, or use a residue-based selection like `'resid 1 to 100'`.
+
+## Linear interaction energy
+
+Splits the nonbonded energy of a selected chain vs. everything else into
+Lennard-Jones and Coulomb components using an OpenMM implicit-solvent (GBn2)
+system.
+
+### Static — single structure
+
+```python
+from molecular_simulations.analysis import StaticInteractionEnergy
+
+ie = StaticInteractionEnergy(
+    'complex.pdb',
+    chain='B',                      # energy between chain B and the rest
+    platform='CUDA',                # 'CUDA' | 'CPU' | 'OpenCL'
+    first_residue=None,             # optional resid range within the chain
+    last_residue=None,
+)
+ie.compute()
+print(ie.lj, ie.coulomb)            # kcal/mol
+```
+
+Use whitespace `chain=' '` if the PDB has no chain IDs.
+
+### Dynamic — over a trajectory
+
+```python
+from molecular_simulations.analysis import DynamicInteractionEnergy
+
+die = DynamicInteractionEnergy(
+    'system.prmtop',
+    'prod.dcd',
+    stride=1,                       # subsample frames
+    chain='A',
+    platform='CUDA',
+    progress_bar=True,
+)
+die.compute_energies()
+print(die.energies.shape)           # (n_frames, 2) -> columns [LJ, Coulomb]
+```
+
+## AutoKMeans — clustering per-frame features
+
+Auto-selects cluster count (silhouette sweep up to `max_clusters`), reduces
+dimensionality (PCA by default), and assigns each frame to a cluster. It loads a
+**directory of `.npy` files** (one per system/replica), so first save your
+features (e.g. averaged fingerprints, distances, CVs) as `.npy`.
+
+```python
+from molecular_simulations.analysis import AutoKMeans
+
+clusterer = AutoKMeans(
+    data_directory='features/',     # globs '<pattern>*.npy'
+    pattern='',                     # filename prefix filter, optional
+    max_clusters=10,
+    stride=1,                       # step size of the cluster-count sweep
+    reduction_algorithm='PCA',
+    reduction_kws={'n_components': 2},
+)
+clusterer.run()
+clusterer.save_labels()             # -> cluster_assignments.parquet (system, frame, cluster)
+clusterer.save_centers()            # -> cluster_centers.json ({cluster: (replica, frame)})
+```
+
+After `run()`: `clusterer.labels` (per-frame assignments), `clusterer.reduced`
+(reduced coords), `clusterer.centers`, and `clusterer.cluster_centers` (maps each
+cluster to the representative `(replica, frame)`).
+
+Dataloaders (pass as `dataloader=`):
+- `GenericDataloader` (default) — stacks `.npy` arrays as-is.
+- `PeriodicDataloader` — for periodic features (e.g. dihedral angles); encodes
+  periodicity before clustering.
+
+Note: `Fingerprinter.save()` writes an **`.npz`**, whereas `AutoKMeans` reads
+**`.npy`**. To cluster fingerprints, extract the array you care about (e.g.
+per-residue mean LJ+ES) and `np.save` it per system into the features directory.
+
+## Scaling out
+Each of these is per-system/per-trajectory work. To process many trajectories,
+wrap the `.run()` / `.compute_energies()` call in a `@python_app` (GPU for the
+OpenMM-based interaction energies, CPU for fingerprinting/clustering) and fan out
+with the `parsl-hpc` skill, then aggregate the outputs.

--- a/skills/analyze-ipsae/SKILL.md
+++ b/skills/analyze-ipsae/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: analyze-ipsae
+description: Score predicted protein complex interfaces with molecular-simulations' ipSAE — computes ipSAE, ipTM, pDockQ, pDockQ2, and LIS per chain pair from a predicted structure plus its pLDDT/PAE confidence arrays. Use when ranking or filtering AlphaFold-Multimer / Boltz / Chai docking predictions by interface confidence, or batch-scoring many predicted models.
+---
+
+# ipSAE interface scoring
+
+`molecular_simulations.analysis.ipSAE` scores a predicted multi-chain structure
+using the predictor's confidence outputs. For each chain pair it computes pDockQ,
+pDockQ2, LIS, ipTM, and ipSAE, returns a Polars DataFrame, and writes
+`ipSAE_scores.parquet`.
+
+## Usage
+
+```python
+from molecular_simulations.analysis import ipSAE
+
+scorer = ipSAE(
+    structure_file='model.pdb',     # predicted complex; .pdb or .cif
+    plddt_file='plddt.npz',         # numpy .npz, key 'plddt'
+    pae_file='pae.npz',             # numpy .npz, key 'pae'  (N x N)
+    out_path='scores/',             # optional; defaults to plddt_file's parent
+    skip_chains={'C'},              # optional; exclude ligand/glycan chains
+)
+scorer.run()
+print(scorer.scores)                # per-chain-pair Polars DataFrame
+# also persisted to <out_path>/ipSAE_scores.parquet
+```
+
+## Inputs
+
+- **`structure_file`** — the predicted model (`.pdb`/`.cif`). Chains are parsed
+  and classified (protein vs. nucleic) internally.
+- **`plddt_file`** — `.npz` containing a `plddt` array (length = number of
+  tokens/residues). Values are auto-scaled: if they look like 0–1 fractions they
+  are multiplied by 100, so either scale works.
+- **`pae_file`** — `.npz` containing a `pae` array, the residue×residue predicted
+  aligned error matrix (N×N).
+- **`out_path`** — output directory (created if absent). Defaults to the parent
+  of `plddt_file`.
+- **`skip_chains`** — set/list of chain IDs to drop before scoring (e.g. ligand
+  or glycan chains). Their pLDDT/PAE tokens are inferred from the remaining
+  tokens and removed so the matrices stay aligned to the scored chains.
+
+Token-count alignment matters: the `plddt` length and `pae` dimensions must
+correspond to the structure's residues (after `skip_chains` removal). Mismatches
+produce wrong scores or indexing errors — confirm your predictor exports pLDDT
+and PAE in the same residue/token order as the structure file.
+
+## Output
+
+`scorer.scores` is a Polars DataFrame with one row per ordered chain pair plus a
+max-value summary (ipSAE is asymmetric, so A→B and B→A both appear). Persist it
+yourself with `scorer.scores.write_parquet(...)`, or read the auto-written
+`ipSAE_scores.parquet`.
+
+Interpreting the metrics (higher = more confident interface):
+- **ipSAE** — interface score from aligned errors (the headline metric here).
+- **ipTM** — interface predicted TM-score.
+- **pDockQ / pDockQ2** — predicted DockQ-style interface quality.
+- **LIS** — local interaction score.
+
+## Batch scoring
+
+Loop over prediction directories and collect the parquet outputs:
+
+```python
+from pathlib import Path
+from molecular_simulations.analysis import ipSAE
+
+for d in Path('/path/to/predictions').glob('model_*'):
+    ipSAE(d / 'model.pdb', d / 'plddt.npz', d / 'pae.npz', out_path=d).run()
+```
+
+For many models, wrap `ipSAE(...).run()` in a CPU `@python_app` and fan out with
+the `parsl-hpc` skill, then concatenate the per-model parquet files with Polars
+for ranking/filtering.
+
+See also: `analyze-sasa` (per-residue solvent accessibility / interface burial).

--- a/skills/analyze-sasa/SKILL.md
+++ b/skills/analyze-sasa/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: analyze-sasa
+description: Compute solvent-accessible surface area on a structure or MD trajectory with molecular-simulations — absolute per-residue SASA (Shrake-Rupley) and RelativeSASA fractional exposure (0=buried, 1=exposed). Use when measuring residue burial/exposure, finding solvent-exposed surfaces or buried interfaces, or quantifying conformational changes in accessibility over a trajectory.
+---
+
+# SASA analysis
+
+`molecular_simulations.analysis.SASA` and `RelativeSASA` implement the
+Shrake-Rupley algorithm as MDAnalysis `AnalysisBase` classes, so they iterate a
+trajectory and accept the standard `run(start=, stop=, step=)` slicing. Results
+are **per-residue** and **averaged over the analyzed frames**.
+
+## Absolute SASA
+
+```python
+import MDAnalysis as mda
+from molecular_simulations.analysis import SASA
+
+u = mda.Universe('system.prmtop', 'prod.dcd')
+sasa = SASA(u.select_atoms('protein'), probe_radius=1.4, n_points=256)
+sasa.run()                       # or run(start=100, stop=500, step=10)
+print(sasa.results.sasa)         # ndarray, one value per residue (Å²)
+```
+
+Arguments:
+- `ag` — an MDAnalysis `AtomGroup` (not a whole Universe).
+- `probe_radius=1.4` — water probe radius in Å (standard).
+- `n_points=256` — points per atomic sphere; higher = more accurate but slower.
+
+Requirements / gotchas:
+- The Universe **must expose an `elements` topology attribute** — atomic radii
+  come from MDAnalysis `vdwradii` keyed on element. AMBER `.prmtop` provides
+  elements; a bare PDB may not (`ValueError` if missing).
+- The AtomGroup must **not** be an `UpdatingAtomGroup` (e.g. avoid
+  `select_atoms(..., updating=True)`) — raises `TypeError`.
+- SASA is summed per residue using `resid` (1-indexed); make sure your selection
+  is contiguous/sensible for the residue indexing you expect.
+
+## Relative SASA (fractional exposure)
+
+`RelativeSASA` adds `results.relative_area` — each residue's SASA divided by its
+maximum accessible area, computed in a **tripeptide context** so the amide
+linkage and neighbors aren't over-counted. Values run 0 (buried) → 1 (exposed).
+
+```python
+from molecular_simulations.analysis import RelativeSASA
+
+u = mda.Universe('system.prmtop', 'prod.dcd')
+rsasa = RelativeSASA(u.select_atoms('protein'))
+rsasa.run()
+print(rsasa.results.sasa)            # absolute SASA (Å²)
+print(rsasa.results.relative_area)   # fractional exposure, 0..1
+```
+
+Extra requirement: the Universe needs a **`bonds`** attribute (the tripeptide
+reference uses a `byres (bonded resindex ...)` selection). AMBER topologies
+include bonds. If you loaded a structure without bonds, add them first, e.g.
+`u.guess_bonds()` or load alongside a topology that defines connectivity.
+
+## Single structure (no trajectory)
+
+Load just the topology/coordinate pair and `run()` over the single frame:
+
+```python
+u = mda.Universe('system.prmtop', 'system.inpcrd')
+SASA(u.select_atoms('protein')).run()
+```
+
+## Tips
+- Subsample long trajectories with `run(step=N)` — SASA is the per-frame
+  bottleneck (KDTree over `n_points` per atom).
+- To map values back to residues, zip `results.sasa` with
+  `ag.residues.resids` / `.resnames`.
+- For interface burial, compute SASA of each partner alone vs. the complex and
+  take the difference (buried surface area).
+- Parallelize across many trajectories with the `parsl-hpc` skill — wrap the
+  `SASA(...).run()` call in a CPU `@python_app`.
+
+See also: `analyze-ipsae` (interface scoring of predicted complexes).

--- a/skills/build-systems/SKILL.md
+++ b/skills/build-systems/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: build-systems
+description: Build AMBER molecular systems (topology + coordinates) for OpenMM simulations with molecular-simulations. Use when preparing a protein, protein-ligand complex, or implicit-solvent system from a PDB/CIF — solvating, neutralizing/ionizing to 150 mM NaCl, parameterizing small molecules with GAFF2, or assigning chains/disulfides before running MD.
+---
+
+# Building molecular systems
+
+The `molecular_simulations.build` module wraps AmberTools (`tleap`, `cpptraj`,
+`antechamber`, `parmchk2`) to turn a structure file into the `.prmtop` topology
+and `.inpcrd` coordinate files that the `run-simulations` workflow expects.
+
+## Prerequisites
+
+- **AmberTools must be installed and `AMBERHOME` set** in the environment. Every
+  builder resolves `tleap`/`cpptraj`/`antechamber` under `$AMBERHOME/bin`. If
+  `AMBERHOME` is unset, construction raises `ValueError`. You can also pass
+  `amberhome='/path/to/amber'` explicitly.
+- Ligand support (`ComplexBuilder`, `LigandBuilder`) needs the optional extras:
+  `pip install molecular-simulations[ligand]` (RDKit + OpenBabel). These are
+  imported lazily — if missing, only the protein-only builders are available.
+
+## Output convention
+
+Builders write `system.prmtop` and `system.inpcrd` (plus `system.pdb`) into the
+output directory, and move all intermediate files into a `build/` subdirectory.
+Point the `Simulator` at that directory — it looks for `system.prmtop` /
+`system.inpcrd` by default.
+
+## Explicit solvent (most common)
+
+Cubic OPC water box, neutralized, then ionized to ~150 mM NaCl.
+
+```python
+from pathlib import Path
+from molecular_simulations.build import ExplicitSolvent
+
+builder = ExplicitSolvent(
+    path=Path('/path/to/outputs'),   # where system.prmtop/.inpcrd land
+    pdb=Path('/path/to/protein.pdb'),
+    padding=10.0,                    # Å of water padding on the longest axis
+)
+builder.build()
+```
+
+Useful options:
+- `disulfide_residues=[23, 88]` — force those residues to `CYX` and let tleap
+  form the bonds (handy for binder design where distance-based detection is
+  unwanted). Otherwise `cpptraj prepareforleap` keeps only `existingdisulfides`.
+- `glycans`, `rna`, `dna`, `phos_protein`, `mod_protein` — booleans that toggle
+  extra `leaprc` force fields (defaults to protein-only ff19SB).
+- `polarizable=True` — switch to ff15ipq / SPC-Eb water.
+- `debug=True` — write the `tleap.in`/cpptraj inputs to disk instead of a temp
+  file so you can inspect them when a build fails.
+
+## Implicit solvent
+
+No water box — produces topology/coords with `mbondi3` radii for GB simulations
+(pair with `ImplicitSimulator`). Note: defaults differ from explicit
+(`glycans=True` by default here).
+
+```python
+from molecular_simulations.build import ImplicitSolvent
+
+builder = ImplicitSolvent(path='/path/to/outputs', pdb='protein.pdb', protein=True)
+builder.build()
+```
+
+## Protein-ligand complex
+
+`ComplexBuilder` extends `ExplicitSolvent`: it parameterizes the ligand(s) with
+GAFF2 (AM1-BCC charges via antechamber/SQM), then combines + solvates.
+
+```python
+from molecular_simulations.build import ComplexBuilder
+
+builder = ComplexBuilder(
+    path='/path/to/outputs',
+    pdb='protein.pdb',
+    lig='ligand.sdf',          # or a list: ['lig0.sdf', 'lig1.sdf']
+    padding=12.0,
+)
+builder.build()
+```
+
+- Ligand residues are named `LG0`, `LG1`, … in the resulting topology.
+- Pass `lig_param_prefix='/path/to/params/ligand'` to reuse pre-computed
+  `.frcmod`/`.lib`/`.mol2` files instead of re-running antechamber.
+- A `LigandError` is raised if antechamber or SQM fails (check the
+  `*_sqm.out` file in `build/` for "Calculation Completed").
+
+To parameterize a ligand on its own, use `LigandBuilder(path, lig, lig_number=0)`
+and call `parameterize_ligand()`.
+
+## Helpers (`molecular_simulations.build`)
+
+- `convert_cif_with_gemmi(cif)` / `convert_cif_with_biopython(cif)` — CIF → PDB.
+- `add_chains(pdb, first_res, last_res)` — assign chain A/B IDs by residue range
+  (writes `*_withchains.pdb`); needed before chain-based MDAnalysis selections in
+  analysis.
+
+## Tips
+
+- Box size is estimated from the longest coordinate axis + `2 * padding`; it is
+  intentionally approximate but fine for periodic boxes.
+- Builds run `tleap`/`cpptraj` with stdout/stderr suppressed. If a system fails
+  silently, re-run with `debug=True` and execute the written `tleap.in` by hand
+  to see the leap log.
+- For HPC fan-out (build many systems in parallel), wrap `builder.build()` in a
+  Parsl `python_app` — see the `parsl-hpc` skill.

--- a/skills/parsl-hpc/SKILL.md
+++ b/skills/parsl-hpc/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: parsl-hpc
+description: Configure Parsl to deploy molecular-simulations builds, MD runs, and analyses across HPC. Use when running many systems/replicas in parallel, picking a compute platform (Local single-node GPU, Heterogeneous GPU+CPU, Polaris, or Aurora via PBSPro), pinning workers to GPUs, or writing/loading a YAML settings file for a cluster job.
+---
+
+# Deploying with Parsl
+
+`molecular_simulations.utils.parsl_settings` provides pydantic `*Settings`
+classes that each emit a ready-made Parsl `Config` via `config_factory(run_dir)`.
+You pick the class for your platform, fill in a few fields (or load from YAML),
+build the config, `parsl.load()` it, then submit work as `@parsl.python_app`s.
+
+## Import path (important)
+
+```python
+from molecular_simulations.utils.parsl_settings import (
+    LocalSettings, LocalCPUSettings, HeterogeneousSettings,
+    PolarisSettings, AuroraSettings,
+)
+```
+
+Only `LocalSettings`, `PolarisSettings`, `AuroraSettings` are re-exported from
+`molecular_simulations.utils`. `HeterogeneousSettings` and `LocalCPUSettings`
+must be imported from the full `...utils.parsl_settings` path. (Note: the
+`examples/run_omm_parsl.py` import `from molecular_simulations.simulate import
+LocalSettings` is wrong — use the `utils` path.)
+
+## The pattern
+
+```python
+import parsl
+from molecular_simulations.utils.parsl_settings import LocalSettings
+
+run_dir = '/path/to/deploy'                    # where Parsl run files go
+settings = LocalSettings(worker_init='source ~/setup_env.sh')
+config = settings.config_factory(run_dir)
+parsl.load(config)
+
+@parsl.python_app
+def run_md(path, eq_steps=500_000, steps=250_000_000):
+    # IMPORTANT: import inside the app so workers can pickle it
+    from molecular_simulations.simulate.omm_simulator import Simulator
+    Simulator(path, equil_steps=eq_steps, prod_steps=steps).run()
+
+from pathlib import Path
+futures = [run_md(str(p)) for p in Path('/path/to/sims').glob('replica_*')]
+outputs = [f.result() for f in futures]         # block until all finish
+```
+
+`worker_init` is shell run on each worker before tasks (activate conda/venv,
+`module load`, set `AMBERHOME`, etc.) — set it on whichever settings class you use.
+
+## Platforms
+
+### LocalSettings — single node, GPU-pinned
+One `HighThroughputExecutor`, workers pinned to local GPUs via
+`available_accelerators` (default 4). Use on a workstation or a single
+interactive compute node. `LocalProvider` + `MpiExecLauncher`.
+
+```python
+LocalSettings(available_accelerators=4, worker_init='...', label='gpu')
+```
+
+### LocalCPUSettings — single node, CPU-only
+For CPU work (e.g. analyses, MM-PBSA). `available_accelerators=[]`,
+`max_workers_per_node` / `cores_per_worker` control concurrency.
+
+### HeterogeneousSettings — single node, GPU **and** CPU executors
+Emits two executors in one config: label `'gpu'` (one worker per accelerator)
+and label `'cpu'`. Use when GPU MD apps and CPU analysis apps run in the same
+workflow — route each `@python_app` to an executor with the `executors=[...]`
+decorator argument.
+
+### PolarisSettings — ALCF Polaris (PBSPro)
+PBSPro provider, 4 GPUs/node (`select_options='ngpus=4'`), `cpu_affinity=
+'alternating'`. Requires scheduler fields:
+
+```python
+PolarisSettings(
+    account='MY_ALLOCATION',
+    queue='debug',                 # or 'prod', etc.
+    walltime='01:00:00',
+    num_nodes=1,
+    worker_init='module load conda; conda activate md',
+    available_accelerators=4,
+    cpus_per_node=64,
+)
+```
+
+### AuroraSettings — ALCF Aurora (PBSPro, Intel GPUs)
+12 accelerator tiles/node (`available_accelerators=[str(i) for i in range(12)]`),
+`max_workers_per_node=12`, `cores_per_worker=16`, `cpu_affinity='block'`. Pair
+with `platform='OpenCL'` in the `Simulator` (Aurora uses Intel GPUs, not CUDA).
+
+```python
+AuroraSettings(
+    account='MY_ALLOCATION',
+    queue='debug',
+    walltime='01:00:00',
+    num_nodes=2,
+)
+```
+
+## YAML config (recommended for cluster jobs)
+
+All settings inherit `from_yaml` / `dump_yaml`, so keep platform config in a file
+and out of code:
+
+```python
+settings = PolarisSettings.from_yaml('config.yaml')
+config = settings.config_factory(run_dir)
+```
+
+```yaml
+# config.yaml
+account: MY_ALLOCATION
+queue: debug
+walltime: "01:00:00"
+num_nodes: 1
+worker_init: "module load conda; conda activate md; export AMBERHOME=..."
+available_accelerators: 4
+```
+
+Generate a starter file with `PolarisSettings(account=..., queue=..., walltime=...
+).dump_yaml('config.yaml')`.
+
+## Notes
+- `PolarisSettings`/`AuroraSettings` require `account`, `queue`, `walltime` (no
+  defaults) — construction fails without them.
+- `Simulator` auto-detects scheduler-masked GPUs (`CUDA_VISIBLE_DEVICES`), so
+  leave `device_ids=[0]` in the app and let Parsl pin accelerators.
+- `max_blocks=1` in the providers by default — one PBS job/block. Edit the
+  settings class if you need multiple concurrent blocks.
+- Run files land under `<run_dir>/runinfo` (Local/Heterogeneous) or `<run_dir>`
+  (Polaris/Aurora).

--- a/skills/run-simulations/SKILL.md
+++ b/skills/run-simulations/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: run-simulations
+description: Run OpenMM molecular dynamics with molecular-simulations — explicit-solvent NPT, implicit-solvent GB, energy minimization, and MM-PBSA binding free energy. Use when launching, configuring, or restarting an MD production run from AMBER/CHARMM inputs, choosing equilibration/production step counts, or selecting GPU/CPU platforms. For running many replicas across HPC nodes, combine with the parsl-hpc skill.
+---
+
+# Running simulations
+
+`molecular_simulations.simulate` drives OpenMM. The main entry point is
+`Simulator`, which runs a full minimize → heat → restrained equilibration →
+NPT production pipeline and handles checkpoint/restart automatically.
+
+## Input convention
+
+`Simulator` reads `system.prmtop` and `system.inpcrd` from `path` by default
+(override with `top_name` / `coor_name`). These are produced by the
+`build-systems` workflow. All outputs (`eq.*`, `prod.dcd`, `prod.log`,
+`prod.chk`, `prod.rst.chk`, `prod.state`) are written to `path` (or `out_path`).
+
+## Explicit solvent (NPT)
+
+```python
+from pathlib import Path
+from molecular_simulations.simulate import Simulator
+
+# Pick step counts from physical time and timestep.
+# Production uses HMR with a 4 fs timestep (0.004 ps) by default.
+ns       = 100                       # production length
+prod_dt  = 0.004                     # ps  (4 fs)
+prod_steps = int(ns / prod_dt * 1000)  # ns -> steps
+
+sim = Simulator(
+    path=Path('/path/to/system_dir'),
+    equil_steps=1_250_000,    # 2.5 ns @ 2 fs (default)
+    prod_steps=prod_steps,
+    temperature=300.0,
+    platform='CUDA',          # 'CUDA' | 'CPU' | 'OpenCL'
+    device_ids=[0],
+)
+sim.run()
+```
+
+What `run()` does:
+1. Skips equilibration if `eq.state`/`eq.chk`/`eq.log` already exist.
+2. Otherwise: minimize, slow-heat 5 K → `temperature` over `heat_steps`,
+   relax backbone restraints in 5 stages, then NPT for `n_equil_cycles`.
+3. Production from the equilibration checkpoint. If `prod.rst.chk` exists it
+   **resumes** automatically, reading `prod.log` to compute remaining steps.
+
+So re-invoking `sim.run()` after a crash continues where it left off — this is
+the intended restart mechanism (important for preemptible HPC queues).
+
+### Key constructor args
+- `heat_steps` (default 100k), `equil_steps` (1.25M), `prod_steps` (250M = ~1 µs).
+- `prod_dt_in_ps=0.004`, `hydrogen_mass_repartitioning=1.5` (amu).
+- `eq_reporter_frequency=1000`, `prod_reporter_frequency=10000` (steps between
+  DCD frames / log lines; checkpoint is written every `prod_freq * 10`).
+- `temperature=300.0`, `force_constant=10.0` (kcal/mol·Å² backbone restraint).
+- `membrane=True` — switch to `MonteCarloMembraneBarostat` (anisotropic).
+- `ff='charmm'` with `params=[...psf params...]` — CHARMM inputs (1.2 nm cutoff);
+  default `ff='amber'` uses PME, 1 nm cutoff, HBond constraints.
+
+### GPU selection
+- On `CUDA`, if `CUDA_VISIBLE_DEVICES` is set (e.g. by Parsl/the scheduler), the
+  in-process device index is forced to `0` because the scheduler already masks
+  and re-indexes GPUs. So don't fight it — let Parsl pin GPUs and leave
+  `device_ids=[0]`. Without that env var, `device_ids` selects physical GPUs.
+
+## Implicit solvent (GB)
+
+```python
+from molecular_simulations.simulate import ImplicitSimulator
+from openmm.app import GBn2
+
+sim = ImplicitSimulator(
+    path='/path/to/system_dir',
+    implicit_solvent=GBn2,         # default
+    prod_steps=100_000_000,
+    solvent_dielectric=78.5,       # 150 mM ionic screening applied via kappa
+)
+sim.run()
+```
+
+Same interface as `Simulator` but no barostat and a shorter equilibration. Build
+the inputs with `ImplicitSolvent` (mbondi3 radii), not `ExplicitSolvent`.
+
+## Energy minimization only
+
+```python
+from molecular_simulations.simulate import Minimizer
+
+Minimizer(
+    topology='system.prmtop',      # or a .pdb (uses amber14-all.xml)
+    coordinates='system.inpcrd',
+    out='min.pdb',
+    platform='OpenCL',
+    device_ids=[0],                # None -> CPU
+).minimize()
+```
+
+## MM-PBSA binding free energy
+
+```python
+from molecular_simulations.simulate import MMPBSA
+```
+
+`MMPBSA` estimates binding free energy in parallel from a complex trajectory.
+Read its docstring/signature for the required selections and decomposition
+options before wiring it up — it expects already-equilibrated trajectories.
+
+## Custom forces
+
+`CustomForcesSimulator(path, custom_force_objects=[...])` (import from
+`molecular_simulations.simulate.omm_simulator`) injects arbitrary OpenMM `Force`
+objects into the system for enhanced sampling — same run pipeline otherwise.
+
+## Tips
+- One `Simulator` == one replica/one system directory. Run many in parallel by
+  globbing replica dirs and submitting each through Parsl (see `parsl-hpc`).
+- Monitor progress via `prod.log` (tab-separated: step, energy, temp, %
+  progress, remaining time, speed, volume).
+- `prod.dcd` frames are written every `prod_reporter_frequency` steps; on restart
+  the reporter appends and any duplicate frames are recorded in
+  `duplicate_frames.log`.


### PR DESCRIPTION
## Summary

Adds agent skills documenting the package's core workflows and fixes two broken example scripts.

### Skills (`skills/`)
Each is a `SKILL.md` (name + description frontmatter) that an agent loads on demand:

| Skill | Use it for |
|-------|------------|
| `build-systems` | Building AMBER systems from PDB/CIF — explicit/implicit solvent, protein-ligand complexes, GAFF2 ligand parameterization |
| `run-simulations` | Running OpenMM MD — explicit NPT, implicit GB, minimization, MM-PBSA, restarts, platform selection |
| `analyze-sasa` | Absolute SASA and RelativeSASA fractional exposure, per residue over a trajectory |
| `analyze-ipsae` | ipSAE interface scoring of predicted complexes — ipSAE, ipTM, pDockQ, pDockQ2, LIS from pLDDT/PAE |
| `analyze-interactions` | Interaction-energy fingerprinting, linear interaction energy (static/dynamic), KMeans clustering |
| `parsl-hpc` | Deploying across HPC with Parsl — Local, Heterogeneous, Polaris, Aurora settings |

`.gitignore` gains `!skills/**/*.md` so these are tracked despite the blanket `*.md` ignore.

### Example fixes
- **`run_omm_locally.py`** — referenced undefined `steps` (variable is `n_steps`); also cast to `int` since OpenMM `step()` rejects floats.
- **`run_omm_parsl.py`** — corrected `LocalSettings` import path to `molecular_simulations.utils.parsl_settings`; `Path`-wrapped `sim_root_dir` before `.glob()`; `int` step count; pass `str(path)` to the app.

## Verification
- All four example scripts pass `py_compile` and every import resolves against the installed package.
- All classes referenced by the skills import cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)