### PR TITLE
docs: fix the strict (-W) build (missing _static, pydantic JsonValue)

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -114,4 +114,10 @@ copybutton_prompt_is_regexp = True
 todo_include_todos = True
 
 # -- Suppress specific warnings ----------------------------------------------
-suppress_warnings = ['autodoc.import']
+# 'sphinx_autodoc_typehints.forward_reference': pydantic re-exports types such
+# as JsonValue as forward references the extension cannot resolve; harmless for
+# our docs but fatal under the strict (-W) build.
+suppress_warnings = [
+    'autodoc.import',
+    'sphinx_autodoc_typehints.forward_reference',
+]


### PR DESCRIPTION
Small CI-hygiene fix for the `docs` job, which has been red on `develop` since the strict (`-W`) build was added.

- **`docs/_static` missing** — the dir was empty/untracked, so fresh CI checkouts lacked it (`html_static_path entry '_static' does not exist`). Adds a `.gitkeep`.
- **pydantic `JsonValue` forward reference** — `sphinx_autodoc_typehints` (added in #8 to fix the import) can't resolve pydantic's re-exported forward references; under CI's sphinx/pydantic versions this aborts the `-W` build. Suppresses that warning category.

Verified the strict build succeeds locally.

**Scope note:** this is docs-only. The `lint` job is a *separate, larger* problem — there is no `.pre-commit-config.yaml` and the repo currently has ~28 files needing `ruff format` plus ~200 `ruff check` violations, so greening it is a dedicated cleanup (best done after the in-flight de-mocking PRs to avoid churn), not a small change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)