### PR TITLE
fix: repair SASA/autocluster/Minimizer source bugs + de-mock tests

### DIFF
--- a/src/molecular_simulations/analysis/autocluster.py
+++ b/src/molecular_simulations/analysis/autocluster.py
@@ -219,6 +219,7 @@ class AutoKMeans:
         stride: int = 1,
         reduction_algorithm: str = 'PCA',
         reduction_kws: dict[str, Any] = {'n_components': 2},  # noqa: B006
+        random_state: int | None = 42,
     ):
         """Initialize the automatic clustering workflow.
 
@@ -230,6 +231,8 @@ class AutoKMeans:
             stride: Step size for cluster number sweep.
             reduction_algorithm: Dimensionality reduction method.
             reduction_kws: Arguments for the reduction algorithm.
+            random_state: Seed for KMeans for reproducible clustering. Defaults
+                to 42; pass None for non-deterministic initialization.
         """
         self.data_dir = Path(data_directory)
         self.dataloader: DataloaderProtocol = dataloader(
@@ -240,6 +243,7 @@ class AutoKMeans:
 
         self.n_clusters = max_clusters
         self.stride = stride
+        self.random_state = random_state
 
         self.decomposition = Decomposition(reduction_algorithm, **reduction_kws)
 
@@ -283,7 +287,7 @@ class AutoKMeans:
             leave=False,
             desc='Sweeping `n_clusters`',
         ):
-            clusterer = KMeans(n_clusters=n)
+            clusterer = KMeans(n_clusters=n, random_state=self.random_state)
             labels = clusterer.fit_predict(self.reduced)
             average_score = silhouette_score(self.reduced, labels)
 

--- a/src/molecular_simulations/analysis/sasa.py
+++ b/src/molecular_simulations/analysis/sasa.py
@@ -123,29 +123,33 @@ class SASA(AnalysisBase):
         Returns:
             Array of per-atom SASA values.
         """
+        # Radii for THIS AtomGroup, which may be a per-residue sub-selection
+        # (e.g. RelativeSASA's tripeptide). self.radii is sized to the full
+        # analysis AtomGroup, so indexing it against `ag` mismatches.
+        radii = np.vectorize(self.radii_dict.get)(ag.elements) + self.probe_radius
+        max_radii = 2 * np.max(radii)
+
         kdt = KDTree(ag.positions, 10)
 
         points = np.zeros(ag.n_atoms)
         for i in range(ag.n_atoms):
-            sphere = self.sphere.copy() * self.radii[i]
+            sphere = self.sphere.copy() * radii[i]
             sphere += ag.positions[i]
             available = self.points_available.copy()
             kdt_sphere = KDTree(sphere, 10)
 
-            for j in kdt.query_ball_point(ag.positions[i], self.max_radii, workers=-1):
+            for j in kdt.query_ball_point(ag.positions[i], max_radii, workers=-1):
                 if j == i:
                     continue
-                if self.radii[j] < (self.radii[i] + self.radii[j]):
+                if radii[j] < (radii[i] + radii[j]):
                     available -= {
                         n
-                        for n in kdt_sphere.query_ball_point(
-                            self.ag.positions[j], self.radii[j]
-                        )
+                        for n in kdt_sphere.query_ball_point(ag.positions[j], radii[j])
                     }
 
             points[i] = len(available)
 
-        return 4 * np.pi * self.radii**2 * points / self.n_points
+        return 4 * np.pi * radii**2 * points / self.n_points
 
     def _prepare(self):
         """Prepare for analysis by initializing results array.

--- a/src/molecular_simulations/simulate/omm_simulator.py
+++ b/src/molecular_simulations/simulate/omm_simulator.py
@@ -954,12 +954,15 @@ class Minimizer:
         self.path = Path(topology).parent
         self.out = self.path / out
         self.platform = Platform.getPlatformByName(platform)
-        self.properties = {'Precision': 'mixed'}
 
-        if device_ids is not None:
-            self.properties.update(
-                {'DeviceIndex': ','.join([str(x) for x in device_ids])}
-            )
+        # The CPU/Reference platforms do not accept a 'Precision' property; only
+        # the GPU platforms do.
+        if platform in ('CPU', 'Reference'):
+            self.properties = {}
+        else:
+            self.properties = {'Precision': 'mixed'}
+            if device_ids is not None:
+                self.properties['DeviceIndex'] = ','.join(str(x) for x in device_ids)
 
     def minimize(self) -> None:
         """Perform energy minimization and save structure.

--- a/tests/test_autocluster.py
+++ b/tests/test_autocluster.py
@@ -186,37 +186,32 @@ class TestAutoKMeans:
             assert auto_km.dataloader is not None
             assert auto_km.decomposition is not None
 
-    @patch('molecular_simulations.analysis.autocluster.silhouette_score')
-    @patch('molecular_simulations.analysis.autocluster.KMeans')
-    def test_sweep_n_clusters(self, mock_kmeans, mock_silhouette):
-        """Test n_clusters parameter sweep"""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            # Create dummy data
-            test_data = np.random.rand(20, 5)
-            file = Path(tmpdir) / 'data.npy'
-            np.save(file, test_data)
+    def test_sweep_n_clusters(self):
+        """sweep_n_clusters runs real KMeans/silhouette and is reproducible."""
+        # Two well-separated 2D blobs: silhouette is maximized at k=2.
+        rng = np.random.default_rng(0)
+        blobs = np.vstack(
+            [rng.normal(0.0, 0.1, (10, 2)), rng.normal(5.0, 0.1, (10, 2))]
+        )
 
-            # Setup mocks
-            mock_kmeans_instance = MagicMock()
-            mock_kmeans_instance.fit_predict.return_value = np.array([0, 1] * 10)
-            mock_kmeans_instance.cluster_centers_ = np.array([[0, 0], [1, 1]])
-            mock_kmeans.return_value = mock_kmeans_instance
+        def run_sweep():
+            with tempfile.TemporaryDirectory() as tmpdir:
+                np.save(Path(tmpdir) / 'data.npy', np.random.rand(20, 5))
+                auto_km = AutoKMeans(tmpdir, max_clusters=5, stride=1, random_state=42)
+                auto_km.reduced = blobs.copy()
+                auto_km.sweep_n_clusters([2, 3, 4])
+                return auto_km
 
-            # Return increasing silhouette scores so we can test best selection
-            mock_silhouette.side_effect = [0.3, 0.5, 0.4]
+        auto_km = run_sweep()
 
-            # Initialize AutoKMeans
-            auto_km = AutoKMeans(tmpdir, max_clusters=5, stride=1)
-            auto_km.reduced = np.random.rand(20, 2)
+        assert auto_km.centers is not None
+        assert auto_km.labels is not None
+        # The two clean blobs are best described by 2 clusters
+        assert len(np.unique(auto_km.labels)) == 2
 
-            # Run sweep
-            auto_km.sweep_n_clusters([2, 3, 4])
-
-            # Check that best score (0.5) was selected
-            assert mock_silhouette.call_count == 3
-            assert mock_kmeans.call_count == 3
-            assert auto_km.centers is not None
-            assert auto_km.labels is not None
+        # Fixed random_state -> identical labels across runs (issue #13)
+        repeat = run_sweep()
+        np.testing.assert_array_equal(auto_km.labels, repeat.labels)
 
     def test_map_centers_to_frames(self):
         """Test mapping cluster centers to frames"""

--- a/tests/test_omm_simulator.py
+++ b/tests/test_omm_simulator.py
@@ -915,55 +915,29 @@ class TestSimulatorProduction:
 class TestMinimizerMethods:
     """Additional tests for Minimizer class."""
 
-    @patch('molecular_simulations.simulate.omm_simulator.Platform')
-    @patch('molecular_simulations.simulate.omm_simulator.AmberInpcrdFile')
-    @patch('molecular_simulations.simulate.omm_simulator.AmberPrmtopFile')
-    @patch('molecular_simulations.simulate.omm_simulator.LangevinMiddleIntegrator')
-    @patch('molecular_simulations.simulate.omm_simulator.Simulation')
-    @patch('molecular_simulations.simulate.omm_simulator.PDBFile')
-    def test_minimizer_minimize(
-        self,
-        mock_pdb,
-        mock_sim_class,
-        mock_integrator,
-        mock_prmtop,
-        mock_inpcrd,
-        mock_platform,
-    ):
-        """Test Minimizer minimize method."""
+    def test_minimizer_minimize(self, real_amber_system_files):
+        """Minimizer.minimize runs a real CPU minimization and writes a PDB."""
+        import MDAnalysis as mda
+
         from molecular_simulations.simulate.omm_simulator import Minimizer
 
-        mock_platform.getPlatformByName.return_value = MagicMock()
-        mock_inpcrd_instance = MagicMock(boxVectors=None)
-        mock_inpcrd_instance.positions = [[0, 0, 0]]
-        mock_inpcrd.return_value = mock_inpcrd_instance
-        mock_topology = MagicMock()
-        mock_topology.createSystem.return_value = MagicMock()
-        mock_topology.topology = MagicMock()
-        mock_prmtop.return_value = mock_topology
+        files = real_amber_system_files
+        minimizer = Minimizer(
+            topology=str(files['prmtop']),
+            coordinates=str(files['inpcrd']),
+            out='minimized.pdb',
+            platform='CPU',
+            device_ids=None,
+        )
+        # CPU platform must not carry a Precision property (issue #19)
+        assert minimizer.properties == {}
 
-        mock_simulation = MagicMock()
-        mock_state = MagicMock()
-        mock_state.getPositions.return_value = [[0, 0, 0]]
-        mock_simulation.context.getState.return_value = mock_state
-        mock_sim_class.return_value = mock_simulation
-        mock_integrator.return_value = MagicMock()
+        minimizer.minimize()
 
-        with tempfile.TemporaryDirectory() as tmpdir:
-            path = Path(tmpdir)
-            top_file = path / 'system.prmtop'
-            top_file.write_text('mock topology')
-            coor_file = path / 'system.inpcrd'
-            coor_file.write_text('mock coordinates')
-
-            minimizer = Minimizer(
-                topology=str(top_file), coordinates=str(coor_file), out='minimized.pdb'
-            )
-
-            minimizer.minimize()
-
-            mock_simulation.minimizeEnergy.assert_called_once()
-            mock_pdb.writeFile.assert_called_once()
+        out = files['path'] / 'minimized.pdb'
+        assert out.exists()
+        # The minimized structure is a valid 22-atom PDB
+        assert mda.Universe(str(out)).atoms.n_atoms == 22
 
 
 class TestImplicitSimulator:

--- a/tests/test_sasa.py
+++ b/tests/test_sasa.py
@@ -177,6 +177,29 @@ class TestSASAIntegration:
             with pytest.raises(ValueError):
                 RelativeSASA(ag)
 
+    @requires_mdanalysis
+    def test_relative_sasa_runs_on_bonded_system(self, real_amber_system_files):
+        """RelativeSASA computes per-residue relative areas on a real system.
+
+        Regression test for the broadcast bug (issue #9): measure_sasa must use
+        the radii of each per-residue sub-selection, not the full AtomGroup.
+        """
+        import MDAnalysis as mda
+
+        from molecular_simulations.analysis import RelativeSASA
+
+        u = mda.Universe(
+            str(real_amber_system_files['prmtop']),
+            str(real_amber_system_files['inpcrd']),
+        )
+        protein = u.select_atoms('protein')
+        rsasa = RelativeSASA(protein)
+        rsasa.run()
+
+        area = rsasa.results.relative_area
+        assert area.shape == (protein.n_residues,)
+        assert np.all(np.isfinite(area))
+
 
 # ============================================================================
 # Original unit tests with mocks


### PR DESCRIPTION
Fixes the three source defects surfaced during the de-mocking effort and converts their tests to real.

## Fixes
- **`analysis/sasa.py` (#9)** — `RelativeSASA.measure_sasa` indexed `self.radii` (sized to the full AtomGroup) and `self.ag.positions` against the per-residue sub-selection it's passed, raising a broadcast `ValueError`. Now computes radii/max-radius from the passed AtomGroup. Reproduced the bug, then added a real RelativeSASA regression test on the bonded prmtop fixture.
- **`analysis/autocluster.py` (#13)** — `AutoKMeans` built `KMeans(n_clusters=n)` with no seed. Added a `random_state` arg (default 42) threaded into `KMeans`. De-mocked `test_sweep_n_clusters` to run real KMeans/silhouette on two separable blobs and assert identical labels across runs.
- **`simulate/omm_simulator.py` (#19)** — `Minimizer.__init__` hardcoded `properties={'Precision': 'mixed'}`, rejected by the CPU/Reference platforms. Now platform-aware (empty for CPU/Reference), mirroring `Simulator`. De-mocked `test_minimizer_minimize` to run a real CPU minimization and assert a valid output PDB.

## Result
Full suite **927 passed, 9 skipped**; pre-commit clean. omm_simulator `Platform` `@patch` sites **9 → 8** (the Minimizer one is now real).

Closes #9, closes #13, closes #19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)