### PR TITLE
feat(cph): single-process pH replica exchange (pH-REMD) prototype

### DIFF
--- a/scripts/ph_remd_hewl.py
+++ b/scripts/ph_remd_hewl.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python
+"""pH replica exchange (pH-REMD) driver for the HEWL constant-pH benchmark.
+
+Builds on ``scripts/benchmark_hewl.py``'s existing ``build`` stage (run that
+first to produce ``hewl/{system.prmtop,system.inpcrd,titratable.json}``) and
+adds a true pH-REMD ``run`` stage. Unlike ``benchmark_hewl.py run``, which
+launches fully INDEPENDENT fixed-pH simulations, this holds every pH-ladder
+rung as a live replica in one process and periodically attempts Metropolis
+exchanges of pH *labels* between adjacent rungs (see
+``molecular_simulations.simulate.constantph.remd.PHREMDDriver``).
+
+Two stages (run ``scripts/benchmark_hewl.py build`` first):
+
+  # 1. Run pH-REMD over a ladder, single process holding all replicas
+  python scripts/ph_remd_hewl.py run --sys hewl --pH-ladder 2.0 2.5 3.0 3.5 4.0 \\
+      --cycles 2000 --steps 500 --exchange-interval 1 \\
+      --platform CUDA --device-ids 0 1 2 3 4 --out hewl/remd_logs
+
+  # 2. UWHAM-reweight the correlated samples into per-residue pKa/Hill fits
+  python scripts/ph_remd_hewl.py analyze --logdir hewl/remd_logs --discard 200 \\
+      --nmr scripts/data/hewl_reference_pka.csv --out hewl
+
+Statistical note: REMD samples ARE correlated across pH (a rank's pH wanders
+via exchanges), so the naive per-pH curve fitting ``benchmark_hewl.py
+analyze`` uses for independent runs is NOT valid here -- this script
+UWHAM-reweights instead (``molecular_simulations...remd.uwham_titration_curves``).
+"""
+
+import argparse
+import csv
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+
+
+def run(args):
+    from molecular_simulations.simulate.constantph.remd import PHREMDDriver
+
+    titratable = json.loads((Path(args.sys) / 'titratable.json').read_text())
+    ladder = sorted(args.pH_ladder)
+
+    device_ids = args.device_ids
+    if args.platform != 'CPU' and device_ids is None:
+        device_ids = list(range(len(ladder)))
+        print(
+            f'--device-ids not given; defaulting to {device_ids} for '
+            f'{len(ladder)} rungs'
+        )
+
+    driver = PHREMDDriver(
+        prmtop_file=Path(args.sys) / 'system.prmtop',
+        inpcrd_file=Path(args.sys) / 'system.inpcrd',
+        titratable=titratable,
+        pH_ladder=ladder,
+        relaxationSteps=args.relaxation_steps,
+        platform_name=args.platform,
+        device_ids=device_ids,
+        seed=args.seed,
+    )
+    print(f'built {len(ladder)} replicas on {args.platform}: {ladder}')
+    driver.run(
+        n_cycles=args.cycles,
+        n_steps=args.steps,
+        exchange_interval=args.exchange_interval,
+        logdir=args.out,
+    )
+    print(f'wrote {args.out}/rank*.csv and {args.out}/exchanges.csv')
+
+
+def analyze(args):
+    import polars as pl
+
+    from molecular_simulations.simulate.constantph.remd import uwham_titration_curves
+
+    rank_files = sorted(Path(args.logdir).glob('rank*.csv'))
+    if not rank_files:
+        raise SystemExit(f'no rank*.csv logs found under {args.logdir}')
+
+    dfs = [pl.read_csv(f)[args.discard :] for f in rank_files]
+    dfs = [df for df in dfs if len(df) > 0]
+    if not dfs:
+        raise SystemExit(
+            f'--discard {args.discard} left no samples in any rank*.csv log'
+        )
+    full = pl.concat(dfs)
+
+    resid_cols = [c for c in full.columns if c.startswith('r') and c[1:].isdigit()]
+    pH_grid = sorted(full['current_pH'].unique().to_list())
+
+    nmr = {}
+    if args.nmr and Path(args.nmr).exists():
+        lines = [
+            ln
+            for ln in Path(args.nmr).read_text().splitlines()
+            if ln.strip() and not ln.lstrip().startswith('#')
+        ]
+        for r in csv.DictReader(lines):
+            nmr[str(r['resnum'])] = (r['resname'], float(r['pKa_exp']))
+
+    fit_results = uwham_titration_curves(full, resid_cols, pH_grid)
+
+    results = []
+    for col in sorted(resid_cols, key=lambda c: int(c[1:])):
+        resnum = col[1:]
+        pKa, hill_n = fit_results[col]
+        resname, exp = nmr.get(resnum, ('?', float('nan')))
+        results.append(
+            {
+                'resnum': resnum,
+                'resname': resname,
+                'pKa_calc': pKa,
+                'hill_n': hill_n,
+                'pKa_exp': exp,
+            }
+        )
+
+    print('\nresnum resname  pKa_calc  hill_n   pKa_exp   error')
+    diffs = []
+    for r in results:
+        err = r['pKa_calc'] - r['pKa_exp']
+        exp_s = f'{r["pKa_exp"]:>6.2f}' if np.isfinite(r['pKa_exp']) else '   n/a'
+        err_s = f'{err:>6.2f}' if np.isfinite(err) else '   n/a'
+        if np.isfinite(err):
+            diffs.append(err)
+        print(
+            f'  {r["resnum"]:>4} {r["resname"]:>4}   {r["pKa_calc"]:>6.2f}   '
+            f'{r["hill_n"]:>5.2f}   {exp_s}   {err_s}'
+        )
+    if diffs:
+        d = np.array(diffs)
+        rmse = float(np.sqrt(np.mean(d**2)))
+        mae = float(np.mean(np.abs(d)))
+        calc = np.array([r['pKa_calc'] for r in results if np.isfinite(r['pKa_exp'])])
+        exp = np.array([r['pKa_exp'] for r in results if np.isfinite(r['pKa_exp'])])
+        corr = float(np.corrcoef(calc, exp)[0, 1]) if len(calc) > 1 else float('nan')
+        print(
+            f'\nN={len(diffs)}  RMSE={rmse:.2f}  MAE={mae:.2f}  R={corr:.2f} '
+            f'pKa units (UWHAM-reweighted)'
+        )
+    else:
+        print('\nNo experimental values matched; provide --nmr to compute RMSE.')
+
+    Path(args.out).mkdir(parents=True, exist_ok=True)
+    (Path(args.out) / 'pka_results_remd.json').write_text(json.dumps(results, indent=2))
+    print(f'wrote {args.out}/pka_results_remd.json')
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    sub = ap.add_subparsers(dest='cmd', required=True)
+
+    r = sub.add_parser('run', help='run pH-REMD (single process, N live replicas)')
+    r.add_argument(
+        '--sys', default='hewl', help='directory from benchmark_hewl.py build'
+    )
+    r.add_argument(
+        '--pH-ladder', type=float, nargs='+', dest='pH_ladder', required=True
+    )
+    r.add_argument('--cycles', type=int, default=2000)
+    r.add_argument('--steps', type=int, default=500)
+    r.add_argument('--exchange-interval', type=int, default=1, dest='exchange_interval')
+    r.add_argument('--relaxation-steps', type=int, default=500, dest='relaxation_steps')
+    r.add_argument('--platform', default='CUDA')
+    r.add_argument('--device-ids', type=int, nargs='+', dest='device_ids', default=None)
+    r.add_argument('--seed', type=int, default=None)
+    r.add_argument('--out', default='hewl/remd_logs')
+    r.set_defaults(func=run)
+
+    a = sub.add_parser('analyze', help='UWHAM-reweight + fit pKa, compare to NMR')
+    a.add_argument('--logdir', default='hewl/remd_logs')
+    a.add_argument(
+        '--nmr', default=str(Path(__file__).parent / 'data' / 'hewl_reference_pka.csv')
+    )
+    a.add_argument(
+        '--discard', type=int, default=200, help='cycles to discard per rank'
+    )
+    a.add_argument('--out', default='hewl')
+    a.set_defaults(func=analyze)
+
+    args = ap.parse_args()
+    args.func(args)
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/src/molecular_simulations/simulate/constantph/remd.py
+++ b/src/molecular_simulations/simulate/constantph/remd.py
@@ -1,0 +1,307 @@
+# ruff: noqa: N815
+"""pH replica exchange (pH-REMD) on top of the discrete-state ConstantPH engine.
+
+Single-process prototype: N ``ConstantPH`` replicas live in one process, one
+per pH-ladder rung, and periodically attempt Metropolis exchanges of pH
+*labels* between adjacent rungs. Swapping labels (not physical
+configurations/positions) makes every potential-energy term cancel exactly
+between the two replicas being considered, leaving only the proton-count/pH
+coupling term -- see :func:`exchange_delta`. This means an exchange attempt
+costs zero extra force evaluations: it only needs each replica's current
+total proton count, which is already cheap plain-Python bookkeeping
+(:func:`total_protons`).
+
+This module intentionally does not modify :class:`ConstantPH` -- a replica
+pinned to a single pH keeps ``self.pH`` as a length-1 list, and reassigning
+its pH label is just ``replica.pH[0] = new_value``.
+"""
+
+import csv
+from contextlib import ExitStack
+from dataclasses import asdict, dataclass, fields
+from pathlib import Path
+
+import numpy as np
+
+
+def exchange_delta(pH_a: float, n_a: int, pH_b: float, n_b: int) -> float:
+    """Reduced-potential difference for swapping the pH labels of two replicas.
+
+    Swapping labels rather than configurations makes every potential-energy
+    term cancel exactly, leaving only the proton/pH coupling term::
+
+        Delta = ln(10) * (pH_b - pH_a) * (n_a - n_b)
+
+    Accept the swap if ``Delta <= 0``, else with probability ``exp(-Delta)``
+    (see :func:`accept_exchange`).
+    """
+    return np.log(10.0) * (pH_b - pH_a) * (n_a - n_b)
+
+
+def accept_exchange(delta: float, rng: np.random.Generator | None = None) -> bool:
+    """Metropolis accept/reject for an :func:`exchange_delta` value."""
+    if delta <= 0.0:
+        return True
+    rng = rng if rng is not None else np.random.default_rng()
+    return bool(rng.random() < np.exp(-delta))
+
+
+def total_protons(replica) -> int:
+    """Total proton count across a replica's titratable residues, current state.
+
+    Same expression ``ConstantPH._attemptPHChange`` uses internally for its
+    own (single-process, simulated-tempering) pH move -- plain Python ints,
+    no OpenMM calls.
+    """
+    return sum(
+        t.explicitStates[t.currentIndex].numHydrogens
+        for t in replica.titrations.values()
+    )
+
+
+@dataclass
+class ExchangeRecord:
+    """One exchange *attempt* (not just accepted swaps) between adjacent rungs."""
+
+    cycle: int
+    rung_low: int
+    rung_high: int
+    replica_low: int
+    replica_high: int
+    pH_low: float
+    pH_high: float
+    n_low: int
+    n_high: int
+    delta: float
+    accepted: bool
+
+
+def _build_replica(
+    prmtop_file, inpcrd_file, pH, titratable, relaxationSteps, platform, properties
+):
+    """Build one ConstantPH replica pinned to a single pH.
+
+    Mirrors ``scripts/benchmark_hewl.py``'s ``_make_cph`` (same explicitArgs/
+    implicitArgs/integrator conventions), extended with an explicit
+    ``properties`` (e.g. ``{'DeviceIndex': ...}``) argument that ``_make_cph``
+    does not support today.
+    """
+    from openmm import LangevinMiddleIntegrator
+    from openmm.app import PME, CutoffNonPeriodic, HBonds
+    from openmm.unit import amu, kelvin, kilojoules_per_mole, nanometers, picosecond
+
+    from molecular_simulations.data import get_ref_energies
+    from molecular_simulations.simulate.constantph.constantph import ConstantPH
+
+    refs = get_ref_energies('amber19')
+    variants = {int(k): v['variants'] for k, v in titratable.items()}
+    reference = {
+        int(k): [e * kilojoules_per_mole for e in refs[v['resname']]]
+        for k, v in titratable.items()
+    }
+    return ConstantPH(
+        prmtop_file=str(prmtop_file),
+        inpcrd_file=str(inpcrd_file),
+        pH=[pH],
+        residueVariants=variants,
+        referenceEnergies=reference,
+        relaxationSteps=relaxationSteps,
+        explicitArgs=dict(
+            nonbondedMethod=PME,
+            nonbondedCutoff=0.9 * nanometers,
+            constraints=HBonds,
+            hydrogenMass=1.5 * amu,
+        ),
+        implicitArgs=dict(
+            nonbondedMethod=CutoffNonPeriodic,
+            nonbondedCutoff=2.0 * nanometers,
+            constraints=HBonds,
+        ),
+        integrator=LangevinMiddleIntegrator(
+            300 * kelvin, 1.0 / picosecond, 0.004 * picosecond
+        ),
+        relaxationIntegrator=LangevinMiddleIntegrator(
+            300 * kelvin, 10.0 / picosecond, 0.002 * picosecond
+        ),
+        platform=platform,
+        properties=properties,
+    )
+
+
+class PHREMDDriver:
+    """Single-process pH replica exchange over N ConstantPH replicas.
+
+    Each replica owns its own OpenMM Context (and, for CUDA, its own device)
+    for the lifetime of the run. Exchange attempts swap only the cheap pH
+    *label* between two replica objects -- never positions, velocities, or
+    protonation state -- so a replica's physical identity (and device) stays
+    fixed while the pH it is currently simulating under wanders.
+    """
+
+    def __init__(
+        self,
+        prmtop_file,
+        inpcrd_file,
+        titratable: dict,
+        pH_ladder: list[float],
+        relaxationSteps: int = 500,
+        temperature: float = 300.0,
+        platform_name: str = 'CPU',
+        device_ids: list[int] | None = None,
+        seed: int | None = None,
+    ):
+        if len(pH_ladder) < 2:
+            raise ValueError('pH_ladder must have at least 2 rungs to exchange between')
+        if platform_name != 'CPU' and (
+            device_ids is None or len(device_ids) != len(pH_ladder)
+        ):
+            got = None if device_ids is None else len(device_ids)
+            raise ValueError(
+                f'device_ids must have one entry per pH-ladder rung when '
+                f'platform_name={platform_name!r} (got {got}, need {len(pH_ladder)})'
+            )
+
+        self.pH_ladder = sorted(pH_ladder)
+        self.temperature = temperature
+        self._rng = np.random.default_rng(seed)
+
+        from openmm import Platform
+
+        platform = Platform.getPlatformByName(platform_name)
+
+        self.replicas = []
+        for i, pH in enumerate(self.pH_ladder):
+            properties = (
+                {'DeviceIndex': str(device_ids[i]), 'Precision': 'mixed'}
+                if platform_name != 'CPU'
+                else None
+            )
+            replica = _build_replica(
+                prmtop_file,
+                inpcrd_file,
+                pH,
+                titratable,
+                relaxationSteps,
+                platform,
+                properties,
+            )
+            replica.simulation.minimizeEnergy()
+            replica.simulation.context.setVelocitiesToTemperature(temperature)
+            self.replicas.append(replica)
+
+        # rung index -> current index into self.replicas (physical slot/device)
+        self.replica_of_rung = list(range(len(self.pH_ladder)))
+        self.resnums = [int(v['pdb_resnum']) for v in titratable.values()]
+        self.resids = [int(k) for k in titratable]
+
+    def attempt_exchange_round(self, cycle: int, parity: int) -> list[ExchangeRecord]:
+        """Attempt exchanges between adjacent rungs at the given parity.
+
+        parity=0 attempts (0,1),(2,3),...; parity=1 attempts (1,2),(3,4),...
+        Every attempt is recorded, not just accepted ones.
+        """
+        records = []
+        n_rungs = len(self.pH_ladder)
+        for k in range(parity, n_rungs - 1, 2):
+            i, j = self.replica_of_rung[k], self.replica_of_rung[k + 1]
+            rep_lo, rep_hi = self.replicas[i], self.replicas[j]
+            pH_lo, pH_hi = self.pH_ladder[k], self.pH_ladder[k + 1]
+            n_lo, n_hi = total_protons(rep_lo), total_protons(rep_hi)
+            delta = exchange_delta(pH_lo, n_lo, pH_hi, n_hi)
+            accepted = accept_exchange(delta, self._rng)
+            if accepted:
+                rep_lo.pH[0], rep_hi.pH[0] = pH_hi, pH_lo
+                self.replica_of_rung[k], self.replica_of_rung[k + 1] = j, i
+            records.append(
+                ExchangeRecord(
+                    cycle, k, k + 1, i, j, pH_lo, pH_hi, n_lo, n_hi, delta, accepted
+                )
+            )
+        return records
+
+    def run(
+        self,
+        n_cycles: int,
+        n_steps: int,
+        exchange_interval: int = 1,
+        logdir: str = 'remd_logs',
+    ) -> None:
+        """Run n_cycles of (step + MC) for every replica, with periodic exchanges.
+
+        Writes one ``rank{i}.csv`` per replica slot (protonation states,
+        current pH *after* that cycle's exchange attempt) and a shared
+        ``exchanges.csv`` (one row per exchange attempt).
+        """
+        logdir_path = Path(logdir)
+        logdir_path.mkdir(parents=True, exist_ok=True)
+
+        with ExitStack() as stack:
+            rank_files = [
+                stack.enter_context(open(logdir_path / f'rank{i}.csv', 'w', newline=''))
+                for i in range(len(self.replicas))
+            ]
+            rank_writers = [csv.writer(fh) for fh in rank_files]
+            for w in rank_writers:
+                w.writerow(
+                    ['cycle', 'rankid', 'current_pH', *[f'r{n}' for n in self.resnums]]
+                )
+
+            exch_fh = stack.enter_context(
+                open(logdir_path / 'exchanges.csv', 'w', newline='')
+            )
+            exch_writer = csv.writer(exch_fh)
+            exch_writer.writerow([f.name for f in fields(ExchangeRecord)])
+
+            parity = 0
+            for cycle in range(n_cycles):
+                for replica in self.replicas:
+                    replica.simulation.step(n_steps)
+                    replica.attemptMCStep(self.temperature)
+
+                if exchange_interval > 0 and cycle % exchange_interval == 0:
+                    records = self.attempt_exchange_round(cycle, parity)
+                    parity = 1 - parity
+                    for rec in records:
+                        exch_writer.writerow(list(asdict(rec).values()))
+
+                for i, replica in enumerate(self.replicas):
+                    row = [cycle, i, replica.pH[0]]
+                    for resid in self.resids:
+                        t = replica.titrations[resid]
+                        row.append(1 if t.currentIndex == t.protonatedIndex else 0)
+                    rank_writers[i].writerow(row)
+
+                if cycle % 100 == 0:
+                    for fh in (*rank_files, exch_fh):
+                        fh.flush()
+
+
+def uwham_titration_curves(df, resid_cols: list[str], pH_grid) -> dict:
+    """Reweight REMD samples across the pH ladder with UWHAM per residue.
+
+    Naive per-pH curve fitting (as ``benchmark_hewl.py analyze`` does for
+    independent fixed-pH runs) is wrong for REMD data, since exchanges
+    correlate samples across pH. UWHAMSolver already exists for exactly this
+    case but was unwired; this is the glue.
+
+    Returns ``{resid_col: (pKa, hill_n)}``.
+    """
+    from molecular_simulations.analysis.constant_pH_analysis import UWHAMSolver
+    from molecular_simulations.simulate.constantph.reference_energy import (
+        fit_titration_midpoint,
+    )
+
+    solver = UWHAMSolver()
+    solver.load_data(df, resid_cols)
+    solver.solve()
+
+    pH_grid = np.asarray(pH_grid, dtype=float)
+    results = {}
+    for resid in resid_cols:
+        fractions = [
+            solver.compute_expectation_at_pH(solver.states[resid], pH) for pH in pH_grid
+        ]
+        results[resid] = fit_titration_midpoint(
+            pH_grid, fractions, pKa0=float(np.median(pH_grid))
+        )
+    return results

--- a/tests/test_ph_remd.py
+++ b/tests/test_ph_remd.py
@@ -1,0 +1,234 @@
+"""Tests for simulate/constantph/remd.py (pH replica exchange)."""
+
+import csv
+import math
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from molecular_simulations.simulate.constantph.remd import (
+    PHREMDDriver,
+    accept_exchange,
+    exchange_delta,
+    total_protons,
+    uwham_titration_curves,
+)
+
+
+def _fake_titration(current_hydrogens):
+    state = SimpleNamespace(numHydrogens=current_hydrogens)
+    return SimpleNamespace(currentIndex=0, explicitStates=[state])
+
+
+def _fake_replica(pH, hydrogens_by_resid):
+    return SimpleNamespace(
+        pH=[pH],
+        titrations={
+            resid: _fake_titration(h) for resid, h in hydrogens_by_resid.items()
+        },
+    )
+
+
+class TestExchangeDelta:
+    @pytest.mark.unit
+    def test_zero_when_symmetric(self) -> None:
+        assert exchange_delta(4.0, 10, 6.0, 10) == 0.0
+
+    @pytest.mark.unit
+    def test_matches_hand_derivation(self) -> None:
+        delta = exchange_delta(4.0, 10, 6.0, 8)
+        assert delta == pytest.approx(math.log(10.0) * (6.0 - 4.0) * (10 - 8))
+
+    @pytest.mark.unit
+    def test_favorable_direction_is_negative(self) -> None:
+        # A (pH 4, 8 protons) trading with B (pH 6, 10 protons): A already has
+        # fewer protons than B, so sending A to the higher pH (where fewer
+        # protons is favored) is thermodynamically favorable -- Delta < 0.
+        assert exchange_delta(pH_a=4.0, n_a=8, pH_b=6.0, n_b=10) < 0
+
+    @pytest.mark.unit
+    def test_unfavorable_direction_is_positive(self) -> None:
+        assert exchange_delta(pH_a=4.0, n_a=10, pH_b=6.0, n_b=8) > 0
+
+    @pytest.mark.unit
+    def test_symmetric_under_relabeling(self) -> None:
+        # Relabeling which replica is "a" and which is "b" describes the same
+        # physical exchange move, so both the (pH_b-pH_a) and (n_a-n_b) factors
+        # flip sign together and the product -- Delta -- is unchanged.
+        d1 = exchange_delta(4.0, 10, 6.0, 8)
+        d2 = exchange_delta(6.0, 8, 4.0, 10)
+        assert d1 == pytest.approx(d2)
+
+
+class TestAcceptExchange:
+    @pytest.mark.unit
+    def test_nonpositive_delta_always_accepts(self) -> None:
+        rng = np.random.default_rng(0)
+        assert accept_exchange(0.0, rng) is True
+        assert accept_exchange(-5.0, rng) is True
+
+    @pytest.mark.unit
+    def test_acceptance_rate_matches_boltzmann_factor(self) -> None:
+        rng = np.random.default_rng(42)
+        delta = 1.5
+        n = 20000
+        accepted = sum(accept_exchange(delta, rng) for _ in range(n))
+        assert accepted / n == pytest.approx(math.exp(-delta), abs=0.02)
+
+    @pytest.mark.unit
+    def test_works_without_explicit_rng(self) -> None:
+        assert accept_exchange(0.0) is True
+
+
+class TestTotalProtons:
+    @pytest.mark.unit
+    def test_sums_current_state_hydrogens_across_residues(self) -> None:
+        replica = SimpleNamespace(
+            titrations={1: _fake_titration(13), 2: _fake_titration(4)}
+        )
+        assert total_protons(replica) == 17
+
+
+class TestAttemptExchangeRound:
+    @pytest.mark.unit
+    def test_accept_swaps_ph_labels_and_replica_of_rung(self) -> None:
+        driver = object.__new__(PHREMDDriver)
+        driver.pH_ladder = [4.0, 6.0]
+        driver.replicas = [_fake_replica(4.0, {1: 8}), _fake_replica(6.0, {1: 10})]
+        driver.replica_of_rung = [0, 1]
+        driver._rng = np.random.default_rng(0)
+
+        # Guaranteed favorable (Delta < 0, see TestExchangeDelta) -> always accepts.
+        records = driver.attempt_exchange_round(cycle=0, parity=0)
+
+        assert len(records) == 1
+        rec = records[0]
+        assert rec.accepted is True
+        assert (rec.rung_low, rec.rung_high) == (0, 1)
+        assert driver.replicas[0].pH[0] == 6.0
+        assert driver.replicas[1].pH[0] == 4.0
+        assert driver.replica_of_rung == [1, 0]
+
+    @pytest.mark.unit
+    def test_reject_leaves_state_untouched(self) -> None:
+        driver = object.__new__(PHREMDDriver)
+        driver.pH_ladder = [4.0, 6.0]
+        # Unfavorable direction (Delta > 0, see TestExchangeDelta).
+        driver.replicas = [_fake_replica(4.0, {1: 10}), _fake_replica(6.0, {1: 8})]
+        driver.replica_of_rung = [0, 1]
+        # A "never accept" RNG: random() always returns 1.0, which is never
+        # less than exp(-delta) for delta > 0.
+        driver._rng = SimpleNamespace(random=lambda: 1.0)
+
+        records = driver.attempt_exchange_round(cycle=0, parity=0)
+
+        assert records[0].accepted is False
+        assert driver.replicas[0].pH[0] == 4.0
+        assert driver.replicas[1].pH[0] == 6.0
+        assert driver.replica_of_rung == [0, 1]
+
+    @pytest.mark.unit
+    def test_parity_selects_correct_adjacent_pairs(self) -> None:
+        driver = object.__new__(PHREMDDriver)
+        driver.pH_ladder = [1.0, 2.0, 3.0, 4.0]
+        driver.replicas = [_fake_replica(pH, {1: 10}) for pH in driver.pH_ladder]
+        driver.replica_of_rung = [0, 1, 2, 3]
+        driver._rng = np.random.default_rng(0)
+
+        even = driver.attempt_exchange_round(cycle=0, parity=0)
+        assert {(r.rung_low, r.rung_high) for r in even} == {(0, 1), (2, 3)}
+
+        driver.replica_of_rung = [0, 1, 2, 3]
+        odd = driver.attempt_exchange_round(cycle=0, parity=1)
+        assert {(r.rung_low, r.rung_high) for r in odd} == {(1, 2)}
+
+
+class TestPHREMDDriverValidation:
+    @pytest.mark.unit
+    def test_requires_at_least_two_rungs(self) -> None:
+        with pytest.raises(ValueError, match='at least 2 rungs'):
+            PHREMDDriver(
+                prmtop_file='x.prmtop',
+                inpcrd_file='x.inpcrd',
+                titratable={},
+                pH_ladder=[5.0],
+            )
+
+    @pytest.mark.unit
+    def test_cuda_requires_matching_device_ids(self) -> None:
+        with pytest.raises(ValueError, match='device_ids'):
+            PHREMDDriver(
+                prmtop_file='x.prmtop',
+                inpcrd_file='x.inpcrd',
+                titratable={},
+                pH_ladder=[4.0, 6.0],
+                platform_name='CUDA',
+                device_ids=[0],
+            )
+
+
+@pytest.mark.integration
+class TestPHREMDDriverIntegration:
+    """End-to-end on the real (CPU) ConstantPH engine, tiny fixture.
+
+    Deliberately does NOT assert that a swap is accepted (that would tie a
+    physics-dependent outcome to an RNG seed and risk CI flakiness) -- the
+    swap *mechanism* is already proven deterministically in
+    TestAttemptExchangeRound above. This test proves the real wiring (actual
+    ConstantPH replicas, actual total_protons reads, actual CSV logging, and
+    the UWHAM glue) works end-to-end without crashing.
+    """
+
+    def test_run_produces_valid_logs_and_uwham_consumes_them(
+        self, real_amber_titratable_solvated_files, skip_without_openmm, tmp_path
+    ) -> None:
+        files = real_amber_titratable_solvated_files
+        titratable = {
+            '1': {'variants': ['LYN', 'LYS'], 'resname': 'LYS', 'pdb_resnum': 1},
+            '2': {'variants': ['ASP', 'ASH'], 'resname': 'ASP', 'pdb_resnum': 2},
+        }
+        pH_ladder = [2.0, 5.0, 8.0]
+
+        driver = PHREMDDriver(
+            prmtop_file=files['prmtop'],
+            inpcrd_file=files['inpcrd'],
+            titratable=titratable,
+            pH_ladder=pH_ladder,
+            relaxationSteps=5,
+            platform_name='CPU',
+            seed=0,
+        )
+
+        logdir = tmp_path / 'remd_logs'
+        driver.run(n_cycles=6, n_steps=5, exchange_interval=1, logdir=str(logdir))
+
+        with open(logdir / 'exchanges.csv') as fh:
+            exch_rows = list(csv.DictReader(fh))
+        # 6 cycles, parity alternates 0,1,0,1,0,1; with 3 rungs each parity
+        # only fits one adjacent pair, so 6 cycles -> 6 total attempts (3 of
+        # each pair).
+        assert len(exch_rows) == 6
+        pairs_seen = {(row['rung_low'], row['rung_high']) for row in exch_rows}
+        assert pairs_seen == {('0', '1'), ('1', '2')}
+        for row in exch_rows:
+            assert math.isfinite(float(row['delta']))
+            assert row['accepted'] in ('True', 'False')
+
+        import polars as pl
+
+        rank_dfs = []
+        for i in range(len(pH_ladder)):
+            df = pl.read_csv(logdir / f'rank{i}.csv')
+            assert set(df.columns) == {'cycle', 'rankid', 'current_pH', 'r1', 'r2'}
+            assert len(df) == 6
+            assert set(df['current_pH'].to_list()) <= set(pH_ladder)
+            rank_dfs.append(df)
+
+        full = pl.concat(rank_dfs)
+        resid_cols = ['r1', 'r2']
+
+        results = uwham_titration_curves(full, resid_cols, pH_grid=pH_ladder)
+        assert set(results) == set(resid_cols)
+        for pKa, _hill_n in results.values():
+            assert math.isfinite(pKa)


### PR DESCRIPTION
## Summary

Buried titratable sites titrate poorly under the existing discrete-state MC engine: a proposed protonation flip is scored on a GB energy without giving the surrounding structure time to relax (rotamer flips, water-channel opening) — a sampling/kinetic-trapping problem, not a titration-mechanism one. pH-REMD is the targeted fix: a stuck buried residue can inherit an already-relaxed alternate-state configuration via exchange with a neighboring-pH replica, instead of needing to cross the barrier unassisted. (Continuous λ-dynamics was considered and deferred — it smooths the titration step but doesn't address kinetic trapping, and is a much larger recalibration project; still on the table as a follow-up if REMD alone isn't enough.)

- `src/molecular_simulations/simulate/constantph/remd.py` — `PHREMDDriver` holds one live `ConstantPH` replica per pH-ladder rung in a single process, steps them in lockstep, and periodically attempts Metropolis exchanges of pH *labels* (not configurations) between adjacent rungs. Swapping labels makes every potential-energy term cancel exactly, so exchange attempts cost zero extra force evaluations. Also wires up `UWHAMSolver` (implemented but never used) to correctly reweight the now-correlated REMD samples.
- `scripts/ph_remd_hewl.py` — `run`/`analyze` CLI mirroring `benchmark_hewl.py`'s shape, reusing its `build` stage and NMR reference data.
- `tests/test_ph_remd.py` — unit tests for the exchange criterion/bookkeeping (no OpenMM) plus a CPU-platform integration test on the existing `lys_ash_solv` fixture.

**No existing file is modified** — `constantph.py`, `cph_simulation.py`, and `benchmark_hewl.py` are all untouched.

## Why draft

Holding off on merge until we've run this at HEWL benchmark scale to confirm it actually improves buried-site pKa accuracy over the existing independent-fixed-pH runs. This PR is the mechanism; the benchmark is the validation.

## Test plan

- [x] `pytest tests/test_ph_remd.py -q` — 15/15 pass (unit + integration)
- [x] `pytest tests/ -q` — full suite passes, no regressions
- [x] `ruff check` / `ruff format` clean
- [x] Manual smoke run (4-rung ladder, CPU, tiny fixture): confirmed real exchange acceptance, replica-slot diffusion across rungs over time, and physically sensible resistance at a large-Δ boundary
- [ ] HEWL-scale REMD run + `analyze` (UWHAM) vs. NMR reference, compared against the existing independent-run benchmark — **blocking merge**

🤖 Generated with [Claude Code](https://claude.com/claude-code)